### PR TITLE
Added infinite scroll to feed pages

### DIFF
--- a/src/Feed.js
+++ b/src/Feed.js
@@ -6,11 +6,11 @@ import Item from "./Item";
 class Feed extends Component {
   state = {
     stories: [],
-    min: 0,
-    max: 30
+    displayNumber: 15
   };
   feedType;
   componentDidMount() {
+    window.addEventListener("scroll", this.handleScroll);
     // Determine which items to fetch based on path
     switch (this.props.location.pathname) {
       case "/":
@@ -45,6 +45,7 @@ class Feed extends Component {
   }
 
   componentWillUnmount() {
+    // Stop listening for changes on the Firebase Websocket when componetWillUnount
     firebase
       .database()
       .ref("/v0")
@@ -52,13 +53,26 @@ class Feed extends Component {
       .off();
   }
 
+  handleScroll = () => {
+    // No more stories to load
+    // This would be a good place to get the next page of results from
+    // the API, but AFAIK that's not supported.
+    if (this.state.displayNumber >= this.state.stories.length) return;
+
+    // At the bottom of the page. Render more stories
+    if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+      const { displayNumber } = this.state;
+      this.setState({ displayNumber: displayNumber + 10 });
+    }
+  };
+
   render() {
-    const { stories, min, max } = this.state;
+    const { stories, displayNumber } = this.state;
 
     if (stories === undefined || stories.length === 0) {
       return <div>Loading...</div>;
     }
-    const storiesToRender = stories.slice(min, max);
+    const storiesToRender = stories.slice(0, displayNumber);
     return (
       <div>
         {storiesToRender.map(id => (


### PR DESCRIPTION
Resolves #15 

I added a scroll event listener to the feed pages. If the scroll reaches the bottom of the page, then I increase `displayNumber` by 10. By doing this in `setState` it slices the story ids with the larger `displayNumber`. 

Since I'm using unique `key` properties for the `<Item>` components, only the new `<Item>` components from the re-render will be loaded.