### PR TITLE
Resolve back button issue

### DIFF
--- a/src/Story.js
+++ b/src/Story.js
@@ -118,7 +118,7 @@ class Story extends Component {
   user = {};
 
   handleStoryClick = event => {
-    if (event.target.tagName !== "A") {
+    if (event.target.tagName !== "A" && !this.props.thread) {
       this.props.history.push(`/item/${this.props.item.id}`);
     }
   };


### PR DESCRIPTION
Resolves #14 

The issue was that clicking on comments caused the `Story` `onclick` event to fire as well because they are children of the `Story` component. So when you collapsed a comment, that called the `onClick` which updated the props.history to be the current item.

With the update, the `onClick` only fires if the thread is not collapsed yet (on the `Feed` page) 